### PR TITLE
Fix AppIndicator description

### DIFF
--- a/gnome-extra/gnome-shell-extension-appindicator/gnome-shell-extension-appindicator-29.ebuild
+++ b/gnome-extra/gnome-shell-extension-appindicator/gnome-shell-extension-appindicator-29.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 inherit gnome2-utils
 
 #MY_PN="${PN/gnome-shell-extension-/}"
-DESCRIPTION="A dock for the Gnome Shell."
+DESCRIPTION="Gnome shell extension for KStatusNotifierItem / AppIndicator support."
 HOMEPAGE="https://github.com/ubuntu/${PN}/"
 SRC_URI="https://github.com/ubuntu/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 

--- a/gnome-extra/gnome-shell-extension-appindicator/gnome-shell-extension-appindicator-33.ebuild
+++ b/gnome-extra/gnome-shell-extension-appindicator/gnome-shell-extension-appindicator-33.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 inherit gnome2-utils
 
 #MY_PN="${PN/gnome-shell-extension-/}"
-DESCRIPTION="A dock for the Gnome Shell."
+DESCRIPTION="Gnome shell extension for KStatusNotifierItem / AppIndicator support."
 HOMEPAGE="https://github.com/ubuntu/${PN}/"
 SRC_URI="https://github.com/ubuntu/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 


### PR DESCRIPTION
Hey ! This is just a little pull request for gnome-shell-extension-appindicator description modification. The old description is the same as Dash To dock. 

Good day, Woomy